### PR TITLE
Update pipelines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,8 @@ jobs:
       id-token: write
     steps:
       - name: mint API token
-         id: mint-token
-         run: |
+        id: mint-token
+        run: |
            # retrieve the ambient OIDC token
            resp=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
              "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=pypi")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,4 +50,3 @@ jobs:
 
       - name: Publish package distribution to PYPI
         uses: pypa/gh-action-pypi-publish@v1.5.0
-        verbose: True

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-       - name: mint API token
+      - name: mint API token
          id: mint-token
          run: |
            # retrieve the ambient OIDC token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,30 @@ jobs:
     permissions:
       id-token: write
     steps:
+       - name: mint API token
+         id: mint-token
+         run: |
+           # retrieve the ambient OIDC token
+           resp=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=pypi")
+           oidc_token=$(jq '.value' <<< "${resp}")
+
+           # exchange the OIDC token for an API token
+           resp=$(curl -X POST https://pypi.org/_/oidc/github/mint-token -d "{\"token\": \"${oidc_token}\"}")
+           api_token=$(jq '.token' <<< "${resp}")
+
+           # mask the newly minted API token, so that we don't accidentally leak it
+           echo "::add-mask::${api_token}"
+
+           # see the next step in the workflow for an example of using this step output
+           echo "api-token=${api_token}" >> "${GITHUB_OUTPUT}"
+
       - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist
 
       - name: Publish package distribution to PYPI
-        uses: pypa/gh-action-pypi-publish@v1.5.0
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          password: ${{ steps.mint-token.outputs.api-token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,9 @@ on:
   release:
     types:
         - published
-
+  pull_request:
+    branches:
+        - main
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -21,8 +23,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.8.0
         env:
-          # List of platforms to build on
-          CIBW_BUILD: cp38-manylinux_x86_64 cp38-win_amd64 cp38-macosx_x86_64 cp38-macosx_arm64
+          # List of platforms to build on (incl. Python version)
+          CIBW_BUILD: cp3{8,9,10}-manylinux_x86_64 cp3{8,9,10}-win_amd64 cp3{8,9,10}-macosx_x86_64 cp38-macosx_arm64
 
           CIBW_BEFORE_BUILD: >
              pip install numpy cython>=0.29.32 scipy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
   upload_pypi:
     needs: [build_wheels]
     runs-on: ubuntu-latest
-    premissions:
+    permissions:
       id-token: write
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,22 +44,8 @@ jobs:
       id-token: write
     steps:
       - name: mint API token
-        id: mint-token
-        run: |
-           # retrieve the ambient OIDC token
-           resp=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=pypi")
-           oidc_token=$(jq '.value' <<< "${resp}")
-
-           # exchange the OIDC token for an API token
-           resp=$(curl -X POST https://pypi.org/_/oidc/github/mint-token -d "{\"token\": \"${oidc_token}\"}")
-           api_token=$(jq '.token' <<< "${resp}")
-
-           # mask the newly minted API token, so that we don't accidentally leak it
-           echo "::add-mask::${api_token}"
-
-           # see the next step in the workflow for an example of using this step output
-           echo "api-token=${api_token}" >> "${GITHUB_OUTPUT}"
+        id: mint
+        uses: tschm/token-mint-action@v1.0.2
 
       - uses: actions/download-artifact@v3
         with:
@@ -69,4 +55,4 @@ jobs:
       - name: Publish package distribution to PYPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ steps.mint-token.outputs.api-token }}
+          password: ${{ steps.mint.outputs.api-token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,7 @@ on:
   release:
     types:
         - published
-  pull_request:
-    branches:
-        - main
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,5 +48,6 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
-
+      - name: Publish package distribution to PYPI
+        uses: pypa/gh-action-pypi-publish@v1.5.0
+        verbose: True

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,8 @@ jobs:
   upload_pypi:
     needs: [build_wheels]
     runs-on: ubuntu-latest
-    # upload to PyPI on every tag starting with 'v'
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    # alternatively, to publish when a GitHub Release is created, use the following rule:
-    # if: github.event_name == 'release' && github.event.action == 'published'
+    premissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -51,7 +49,4 @@ jobs:
           path: dist
 
       - uses: pypa/gh-action-pypi-publish@v1.5.0
-        with:
-          user: __token__
-          verbose: True
-          password: ${{ secrets.PYPI_API_TOKEN_QUICKBAYES }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,6 @@ jobs:
           path: dist
 
       - name: Publish package distribution to PYPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ steps.mint-token.outputs.api-token }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
            os: [windows-latest, ubuntu-latest, macOS-latest]
-           python_version: ['3.8', '3.9', '3.10', '3.11']
+           python_version: ['3.8', '3.9', '3.10']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
            os: [windows-latest, ubuntu-latest, macOS-latest]
-
+           python_version: ['3.8', '3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -32,8 +32,8 @@ jobs:
       - name: create_yml_file
         shell: bash -l {0}
         run:  |
-             echo ${{ matrix.os }}
-             python tools/create_conda_yml.py ${{ matrix.os }}
+             echo ${{ matrix.os }} ${{matrix.python_version}}
+             python tools/create_conda_yml.py ${{ matrix.os }} ${{matrix.python_version}}
       - name: Setup Mambaforge windows
         if: matrix.os == 'windows-latest'
         uses: conda-incubator/setup-miniconda@v2.1.1
@@ -55,7 +55,7 @@ jobs:
           environment-file: quickBayes-dev-linux.yml
           auto-activate-base: false
           use-mamba: true
-          
+
       - name: Setup Mambaforge mac
         if: matrix.os == 'macOS-latest'
         uses: conda-incubator/setup-miniconda@v2.1.1
@@ -66,7 +66,7 @@ jobs:
           environment-file: quickBayes-dev-mac.yml
           auto-activate-base: false
           use-mamba: true
-          
+
       - name: check install
         shell: bash -l {0}
         run:  |

--- a/quickBayes-dev-linux.yml
+++ b/quickBayes-dev-linux.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python =3.8.*
+  - python =3.10.*
   - numpy =1.16.*
   - scipy
   - pytest

--- a/quickBayes-dev-linux.yml
+++ b/quickBayes-dev-linux.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   - python =3.10.*
-  - numpy =1.16.*
+  - numpy
   - scipy
   - pytest
   - pre-commit >=2.15

--- a/quickBayes-dev-mac.yml
+++ b/quickBayes-dev-mac.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python =3.8.*
+  - python =3.10.*
   - numpy =1.16.*
   - scipy
   - pytest

--- a/quickBayes-dev-mac.yml
+++ b/quickBayes-dev-mac.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   - python =3.10.*
-  - numpy =1.16.*
+  - numpy
   - scipy
   - pytest
   - pre-commit >=2.15

--- a/quickBayes-dev-win.yml
+++ b/quickBayes-dev-win.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python =3.8.*
+  - python =3.10.*
   - numpy =1.16.*
   - scipy
   - pytest

--- a/quickBayes-dev-win.yml
+++ b/quickBayes-dev-win.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   - python =3.10.*
-  - numpy =1.16.*
+  - numpy
   - scipy
   - pytest
   - pre-commit >=2.15

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 from tools.setup_helper import get_extensions
 
 
-VERSION = "1.0.0b8"
+VERSION = "1.0.0b9"
 PACKAGE_NAME = 'quickBayes'
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 from tools.setup_helper import get_extensions
 
 
-VERSION = "1.0.0b9"
+VERSION = "1.0.0b10"
 PACKAGE_NAME = 'quickBayes'
 
 

--- a/tools/create_conda_yml.py
+++ b/tools/create_conda_yml.py
@@ -14,7 +14,8 @@ supported = ['windows', 'ubuntu', 'windows-latest', 'ubuntu-latest',
              'mac', 'macOS-latest']
 exp = []
 
-versions = ['3.8', '3.9', '3.10', '3.11']
+# cannot support 3.11 until gofit does
+versions = ['3.8', '3.9', '3.10']
 
 
 def get_input():
@@ -29,7 +30,7 @@ def get_input():
                         ' mac, macOS-latest', type=str)
     parser.add_argument('version',
                         help='the Python version'
-                        ' (3.8, 3.9, 3.10, 3.11)', type=str)
+                        ' (3.8, 3.9, 3.10)', type=str)
     args = parser.parse_args()
 
     if args.OS not in supported and args.OS not in exp:

--- a/tools/create_conda_yml.py
+++ b/tools/create_conda_yml.py
@@ -84,7 +84,7 @@ def create_default(version):
     default_yml['name'] = 'quickBayes-dev'
     default_yml['channels'] = 'conda-forge'
     default_yml['dependencies'] = {'python': '=' + version + '.*',
-                                   'numpy': '=1.16.*',
+                                   'numpy': '',
                                    'scipy': '',
                                    'pytest': '',
                                    'pre-commit': '>=2.15',

--- a/tools/create_conda_yml.py
+++ b/tools/create_conda_yml.py
@@ -14,31 +14,42 @@ supported = ['windows', 'ubuntu', 'windows-latest', 'ubuntu-latest',
              'mac', 'macOS-latest']
 exp = []
 
+versions = ['3.8', '3.9', '3.10', '3.11']
 
-def get_OS():
+
+def get_input():
     """
-    get the OS from the command line arg
+    get the OS and version from the command line arg
+    :returns the OS and Python version
     """
     parser = argparse.ArgumentParser()
     parser.add_argument('OS',
                         help='the OS for the yml file'
                         ' (windows, windows-latest, ubuntu, ubuntu-latest,'
                         ' mac, macOS-latest', type=str)
+    parser.add_argument('version',
+                        help='the Python version'
+                        ' (3.8, 3.9, 3.10, 3.11)', type=str)
     args = parser.parse_args()
 
     if args.OS not in supported and args.OS not in exp:
         raise ValueError(str(args.OS) + ' is not a supported OS.')
-    print(args.OS)
-    return args.OS
+
+    if args.version not in versions:
+        raise ValueError(str(args.version) + ' is not a supported'
+                                             ' Python version.')
+    print(args.OS, args.version)
+    return args.OS, args.version
 
 
-def get_OS_info(OS):
+def get_OS_info(OS, version):
     """
     Gets the yml_dict and file name from the OS
     :param OS: the OS the file is for
+    :param version: the Python version
     :Return a dict of contents for the yml file and file name
     """
-    default_yml = create_default()
+    default_yml = create_default(version)
     if OS == 'mac' or OS == 'macOS-latest':
         yml_dict = for_mac(default_yml)
         file_name = str(yml_dict["name"])+'-mac.yml'
@@ -58,11 +69,12 @@ methods to modify it for specific OS's.
 """
 
 
-def create_default():
+def create_default(version):
     """
     The default yml file for all OS's.
     Should only change these values if there is a
     good reason.
+    :param version: Python version to build (exclude patch)
     """
     default_yml = {}
 
@@ -71,7 +83,7 @@ def create_default():
 
     default_yml['name'] = 'quickBayes-dev'
     default_yml['channels'] = 'conda-forge'
-    default_yml['dependencies'] = {'python': '=3.8.*',
+    default_yml['dependencies'] = {'python': '=' + version + '.*',
                                    'numpy': '=1.16.*',
                                    'scipy': '',
                                    'pytest': '',
@@ -109,8 +121,8 @@ def for_mac(yml_dict):
 
 if __name__ == "__main__":
     try:
-        OS = get_OS()
-        yml_dict, file_name = get_OS_info(OS)
+        OS, version = get_input()
+        yml_dict, file_name = get_OS_info(OS, version)
         with open(file_name, 'w') as outfile:
             write_conda_yml_from_dict(yml_dict, outfile)
 


### PR DESCRIPTION
This PR update the pipelines:

1. It allows us to test against Python 3.8, 3.9 and 3.10
2. It allows us to build against Python 3.8, 3.9 and 3.10
3. It now uses the PYPI trusted publisher

fixes #64 

To test:
1. check the automated tests are against all 3 expected versions
2. see that the repo has been updated https://pypi.org/project/quickBayes/#history