### PR TITLE
Add basic parallel processing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Build and upload to PyPI
 
 on:
+  pull_request:
+    branches:
+      - main
   release:
     types:
         - published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Build and upload to PyPI
 
 on:
-  pull_request:
-    branches:
-      - main
   release:
     types:
         - published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           CIBW_BUILD: cp3{8,9,10}-manylinux_x86_64 cp3{8,9,10}-win_amd64 cp3{8,9,10}-macosx_x86_64 cp38-macosx_arm64
 
           CIBW_BEFORE_BUILD: >
-             pip install numpy cython>=0.29.32 scipy
+             pip install numpy cython==0.29.32 scipy joblib
 
           # Install test dependencies and run tests
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
              pip install numpy cython==0.29.32 scipy joblib
 
           # Install test dependencies and run tests
-          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_REQUIRES: pytest joblib
           CIBW_TEST_COMMAND: >
             pytest {project}/test
       - uses: actions/upload-artifact@v3

--- a/docs/source/dev/index.rst
+++ b/docs/source/dev/index.rst
@@ -1,0 +1,17 @@
+.. quickBayes documentation master file, created by
+   sphinx-quickstart on Mon Apr  3 15:37:35 2023.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Developer documents
+===================
+
+Contents
+--------
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   parallel
+

--- a/docs/source/dev/parallel.rst
+++ b/docs/source/dev/parallel.rst
@@ -86,5 +86,5 @@ The :code:`parallel` function can even be used with a method from a class.
    result = test.parallel_function(inputs, const)
    print(result)
 
-It is important to note that the method call is to a wrapper of themethod function we want to run in parallel.
+It is important to note that the method call is to a wrapper of the method function we want to run in parallel.
 

--- a/docs/source/dev/parallel.rst
+++ b/docs/source/dev/parallel.rst
@@ -5,26 +5,86 @@ The parallel function is included to make it easier to do similar calculations f
 The parallel function uses `Joblib <https://joblib.readthedocs.io/en/stable/index.html>`_.
 
 A simple example is:
+
 .. code-block:: python
-  :linenos:
-        import time
-        import numpy as np
-        import multiprocessing
-        from multiprocessing import Pool, freeze_support
-        from multiprocessing import Pool
-        from joblib import Parallel, delayed
+
+  import time
+  import numpy as np
+  from quickBayes.utils.parallel import parallel
 
 
-        start = time.time()
+  def do_thing(j):
+          time.sleep(0.5)
+          return -j
 
-        def do_thing(j):
-                time.sleep(0.5)
-                return -j
+  data = np.zeros(100)
 
-        data = np.zeros(100)
+  start = time.time()
+  data = Parallel(list(range(100)), do_thing)
+  print(data)
+  print(time.time() - start)
 
-        data = Parallel(list(range(100)), do_thing)
-        print(data)
-        print(time.time() - start)
+Notice that the output is a list of the results from the :code:`do_thing` function and that the :code:`range` has to be converted to a list.
 
-Notice that the output is a list of the results from the `do_thing` function.
+If you have multiple inputs then you can pass them by using tuples.
+
+.. code-block:: python
+
+   from quickBayes.utils.parallel import parallel
+
+   def function(input):
+       i = input[0]
+       j = input[1]
+       return i*j
+
+   inputs = [ (k, -k) for k in range(10)]
+   result = parallel(inputs, function)
+   print(result)
+
+There will be some occasions when some of the parameters are the same for all of the parallel functions.
+For this case the :code:`partial` function of :code:`functools` can be used:
+
+.. code-block:: python
+
+   from functools import partial
+   from quickBayes.utils.parallel import parallel
+
+   def function(input, offset):
+       i = input[0]
+       j = input[1]
+       return i*j - offset
+
+   inputs = [ (k, -k) for k in range(10)]
+   const = 3.
+   partial_function = partial(function, offset=const)
+   result = parallel(inputs, partial_function)
+   print(result)
+
+The :code:`parallel` function can even be used with a method from a class.
+
+.. code-block:: python
+
+   from functools import partial
+   from quickBayes.utils.parallel import parallel
+
+   class test_parallel(object):
+       def __init__(self, offset):
+           self._offset = offset
+
+       def function(self, input, constant):
+           i = input[0]
+           j = input[1]
+           return i*j - constant*self._offset
+
+       def parallel_function(self, values, constant):
+           partial_function = partial(self.function, constant=constant)
+           return parallel(values, partial_function)
+
+   inputs = [ (k, -k) for k in range(10)]
+   const = 3.
+   test = test_parallel(2.)
+   result = test.parallel_function(inputs, const)
+   print(result)
+
+It is important to note that the method call is to a wrapper of themethod function we want to run in parallel.
+

--- a/docs/source/dev/parallel.rst
+++ b/docs/source/dev/parallel.rst
@@ -1,0 +1,30 @@
+Parallel
+========
+
+The parallel function is included to make it easier to do similar calculations faster.
+The parallel function uses `Joblib <https://joblib.readthedocs.io/en/stable/index.html>`_.
+
+A simple example is:
+.. code-block:: python
+  :linenos:
+        import time
+        import numpy as np
+        import multiprocessing
+        from multiprocessing import Pool, freeze_support
+        from multiprocessing import Pool
+        from joblib import Parallel, delayed
+
+
+        start = time.time()
+
+        def do_thing(j):
+                time.sleep(0.5)
+                return -j
+
+        data = np.zeros(100)
+
+        data = Parallel(list(range(100)), do_thing)
+        print(data)
+        print(time.time() - start)
+
+Notice that the output is a list of the results from the `do_thing` function.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,7 @@ Contents
    Fitting <fitting/index>
    Workflows <workflows/index>
    Tutorial <tutorial/index>
+   Developer docs <dev/index>
    usage
    api
 

--- a/docs/source/loglikelihood.rst
+++ b/docs/source/loglikelihood.rst
@@ -24,5 +24,3 @@ to get:
     \sum_{j=1}{N}\log(j) + N\log(4\pi) - 0.5\chi^2\log(\exp(1))
     - N\log(\beta) - 0.5\log(\det(H))
 
-
-

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -3,3 +3,4 @@ Test
 
 .. autofunction:: quickBayes.log_likelihood.loglikelihood
 .. autofunction:: quickBayes.fit_engines.scipy_fit_engine.ScipyFitEngine
+.. autofunction:: quickBayes.utils.parallel.parallel

--- a/quickBayes-dev-linux.yml
+++ b/quickBayes-dev-linux.yml
@@ -9,6 +9,7 @@ dependencies:
   - scipy
   - pytest
   - pre-commit >=2.15
+  - joblib
   - pip:
-    - cython
+    - cython ==0.29.*
     - gofit

--- a/quickBayes-dev-mac.yml
+++ b/quickBayes-dev-mac.yml
@@ -9,6 +9,7 @@ dependencies:
   - scipy
   - pytest
   - pre-commit >=2.15
+  - joblib
   - pip:
-    - cython
+    - cython ==0.29.*
     - gofit

--- a/quickBayes-dev-win.yml
+++ b/quickBayes-dev-win.yml
@@ -9,6 +9,7 @@ dependencies:
   - scipy
   - pytest
   - pre-commit >=2.15
+  - joblib
   - pip:
-    - cython
+    - cython ==0.29.*
     - gofit

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 from tools.setup_helper import get_extensions
 
 
-VERSION = "1.0.0b11"
+VERSION = "1.0.0b12"
 PACKAGE_NAME = 'quickBayes'
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 from tools.setup_helper import get_extensions
 
 
-VERSION = "1.0.0b10"
+VERSION = "1.0.0b11"
 PACKAGE_NAME = 'quickBayes'
 
 

--- a/src/quickBayes/utils/makefile.txt
+++ b/src/quickBayes/utils/makefile.txt
@@ -1,3 +1,4 @@
 utils.general: join('utils', 'general.py')
 utils.spline: join('utils', 'spline.py')
 utils.crop_data: join('utils', 'crop_data.py')
+utils.parallel: join('utils', 'parallel.py')

--- a/src/quickBayes/utils/parallel.py
+++ b/src/quickBayes/utils/parallel.py
@@ -1,0 +1,6 @@
+import multiprocessing
+from joblib import Parallel, delayed
+
+
+def parallel(max_: int, function, N: int = multiprocessing.cpu_count()):
+    return Parallel(n_jobs=N)(delayed(function)(j) for j in range(max_))

--- a/src/quickBayes/utils/parallel.py
+++ b/src/quickBayes/utils/parallel.py
@@ -1,8 +1,10 @@
 import multiprocessing
 from joblib import Parallel, delayed
+from collections.abc import Callable
 
 
-def parallel(items: list, function, N: int = multiprocessing.cpu_count()):
+def parallel(items: list, function: Callable,
+             N: int = multiprocessing.cpu_count()):
     """
     This is a wrapper of the joblib Parallel function.
     It will run the function over multiple cores and then return the result.

--- a/src/quickBayes/utils/parallel.py
+++ b/src/quickBayes/utils/parallel.py
@@ -2,5 +2,16 @@ import multiprocessing
 from joblib import Parallel, delayed
 
 
-def parallel(max_: int, function, N: int = multiprocessing.cpu_count()):
-    return Parallel(n_jobs=N)(delayed(function)(j) for j in range(max_))
+def parallel(items: list, function, N: int = multiprocessing.cpu_count()):
+    """
+    This is a wrapper of the joblib Parallel function.
+    It will run the function over multiple cores and then return the result.
+    Note that the function must take the looped value as its only input.
+    :input items: the list to loop over
+    :input function: the function to run in parallel
+    :input N: the number of process to use
+    :return a list of the outputs from function. If multuple outputs
+    from function then the first index is for the loop value and the
+    second index is for the item from function.
+    """
+    return Parallel(n_jobs=N)(delayed(function)(j) for j in items)

--- a/src/quickBayes/utils/parallel.py
+++ b/src/quickBayes/utils/parallel.py
@@ -9,6 +9,7 @@ def parallel(items: list, function: Callable,
     This is a wrapper of the joblib Parallel function.
     It will run the function over multiple cores and then return the result.
     Note that the function must take the looped value as its only input.
+    Use threads as the default does not work with Mantid.
     :input items: the list to loop over
     :input function: the function to run in parallel
     :input N: the number of process to use
@@ -16,4 +17,5 @@ def parallel(items: list, function: Callable,
     from function then the first index is for the loop value and the
     second index is for the item from function.
     """
-    return Parallel(n_jobs=N)(delayed(function)(j) for j in items)
+    return Parallel(n_jobs=N,
+                    prefer="threads")(delayed(function)(j) for j in items)

--- a/test/utils/parallel_test.py
+++ b/test/utils/parallel_test.py
@@ -23,12 +23,12 @@ def function(j):
      new_x, fits, fit_e) = qse_data_main(sample, resolution,
                                          "linear", -0.4, 0.4, True,
                                          results, errors)
-    return results
+    return results, j
 
 
 class ParallelTest(unittest.TestCase):
 
-    def test_parallel(self):
+    def test_parallelSpeed(self):
 
         start = time.time()
         a = []
@@ -37,10 +37,23 @@ class ParallelTest(unittest.TestCase):
         serial = time.time() - start
 
         start = time.time()
-        _ = parallel(6, function)
+        _ = parallel(list(range(6)), function)
         parallel_time = time.time() - start
 
         self.assertLess(parallel_time, serial)
+
+    def test_parallelResults(self):
+
+        data = parallel(list(range(2)), function)
+        first = data[0][0]
+        second = data[1][0]
+        self.assertEqual(first.keys(), second.keys())
+        for key in first.keys():
+            self.assertEqual(first[key], second[key])
+
+        # check the j's
+        self.assertEqual(data[0][1], 0)
+        self.assertEqual(data[1][1], 1)
 
 
 if __name__ == '__main__':

--- a/test/utils/parallel_test.py
+++ b/test/utils/parallel_test.py
@@ -1,0 +1,47 @@
+import unittest
+from quickBayes.workflow.QSE import qse_data_main
+from quickBayes.utils.parallel import parallel
+import numpy as np
+import os.path
+import time
+
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+
+
+def function(j):
+
+    sx, sy, se = np.load(os.path.join(DATA_DIR, 'sample_data_red.npy'))
+    rx, ry, re = np.load(os.path.join(DATA_DIR, 'qse_res.npy'),
+                         allow_pickle=True)
+
+    sample = {'x': sx, 'y': sy, 'e': se}
+    resolution = {'x': rx, 'y': ry}
+    results = {}
+    errors = {}
+    (results, errors,
+     new_x, fits, fit_e) = qse_data_main(sample, resolution,
+                                         "linear", -0.4, 0.4, True,
+                                         results, errors)
+    return results
+
+
+class ParallelTest(unittest.TestCase):
+
+    def test_parallel(self):
+
+        start = time.time()
+        a = []
+        for j in range(6):
+            a.append(function(j))
+        serial = time.time() - start
+
+        start = time.time()
+        _ = parallel(6, function)
+        parallel_time = time.time() - start
+
+        self.assertLess(parallel_time, serial)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/create_conda_yml.py
+++ b/tools/create_conda_yml.py
@@ -79,7 +79,7 @@ def create_default(version):
     """
     default_yml = {}
 
-    pip_dict = {'cython': '',
+    pip_dict = {'cython': '==0.29.*',
                 'gofit': ''}
 
     default_yml['name'] = 'quickBayes-dev'

--- a/tools/create_conda_yml.py
+++ b/tools/create_conda_yml.py
@@ -76,6 +76,7 @@ def create_default():
                                    'scipy': '',
                                    'pytest': '',
                                    'pre-commit': '>=2.15',
+                                   'joblib': '',
                                    'pip': pip_dict}
     return default_yml
 


### PR DESCRIPTION
This PR does 2 things:

1. Adds the basic tools to do parallel processing
2. Pins Cython see https://github.com/mantidproject/quickBayes/issues/70

The new parallel function just takes a counter. This is good for our purpose as the idea is to use it to parallelise over the workspace index. 

To check the docs click details on the read the docs build. 