### PR TITLE
fix EISF error report

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Build and upload to PyPI
 
 on:
-  pull_request:
-    branches:
-      - 'main'
   release:
     types:
         - published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Build and upload to PyPI
 
 on:
+  pull-request:
+    branches:
+      -main
   release:
     types:
         - published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Build and upload to PyPI
 
 on:
-  pull-request:
+  pull_request:
     branches:
-      -main
+      - 'main'
   release:
     types:
         - published

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 from tools.setup_helper import get_extensions
 
 
-VERSION = "1.0.0b14"
+VERSION = "1.0.0b15"
 
 
 PACKAGE_NAME = 'quickBayes'

--- a/src/quickBayes/fit_functions/qldata_function.py
+++ b/src/quickBayes/fit_functions/qldata_function.py
@@ -85,8 +85,9 @@ class QlDataFunction(QEFunction):
                 k = j + 1
                 N_qe = self.conv._funcs[k].N_params
                 # params has values for delta + lorentz
-                qe_amp = params[j*N_qe + N_e]
-                sigma_qe_amp = errors[j*N_qe + N_e]
+                qe_index = j*(N_qe - 1) + N_e #  -1 due to shared param
+                qe_amp = params[qe_index]
+                sigma_qe_amp = errors[qe_index]
                 EISF = sqrt(((qe_amp**2)*(sigma_e_amp**2) +
                              (sigma_qe_amp**2)*(e_amp**2))/pow(e_amp +
                                                                qe_amp, 4))

--- a/src/quickBayes/fit_functions/qldata_function.py
+++ b/src/quickBayes/fit_functions/qldata_function.py
@@ -85,7 +85,7 @@ class QlDataFunction(QEFunction):
                 k = j + 1
                 N_qe = self.conv._funcs[k].N_params
                 # params has values for delta + lorentz
-                qe_index = j*(N_qe - 1) + N_e #  -1 due to shared param
+                qe_index = j*(N_qe - 1) + N_e  # -1 due to shared param
                 qe_amp = params[qe_index]
                 sigma_qe_amp = errors[qe_index]
                 EISF = sqrt(((qe_amp**2)*(sigma_e_amp**2) +

--- a/test/workflows/model_selection/qldata_test.py
+++ b/test/workflows/model_selection/qldata_test.py
@@ -101,7 +101,7 @@ class QlDataTest(unittest.TestCase):
         self.assertAlmostEqual(errors['N2:f2.f3.EISF'][0], 0.011, 3)
 
         self.assertAlmostEqual(errors['N3:f2.f2.EISF'][0], 0.4, 1)
-        self.assertAlmostEqual(errors['N3:f2.f3.EISF'][0], 0.02, 2)
+        self.assertAlmostEqual(errors['N3:f2.f3.EISF'][0], 0.0116, 3)
         self.assertAlmostEqual(errors['N3:f2.f4.EISF'][0], 0.3, 1)
 
     def test_two(self):

--- a/test/workflows/model_selection/qldata_test.py
+++ b/test/workflows/model_selection/qldata_test.py
@@ -98,7 +98,7 @@ class QlDataTest(unittest.TestCase):
         self.assertAlmostEqual(errors['N1:f2.f2.EISF'][0], 0.006, 3)
 
         self.assertAlmostEqual(errors['N2:f2.f2.EISF'][0], 0.02, 2)
-        self.assertAlmostEqual(errors['N2:f2.f3.EISF'][0], 0.002, 3)
+        self.assertAlmostEqual(errors['N2:f2.f3.EISF'][0], 0.011, 3)
 
         self.assertAlmostEqual(errors['N3:f2.f2.EISF'][0], 0.4, 1)
         self.assertAlmostEqual(errors['N3:f2.f3.EISF'][0], 0.02, 2)

--- a/test/workflows/model_selection/qldata_test.py
+++ b/test/workflows/model_selection/qldata_test.py
@@ -102,7 +102,7 @@ class QlDataTest(unittest.TestCase):
 
         self.assertAlmostEqual(errors['N3:f2.f2.EISF'][0], 0.4, 1)
         self.assertAlmostEqual(errors['N3:f2.f3.EISF'][0], 0.116, 2)
-        self.assertAlmostEqual(errors['N3:f2.f4.EISF'][0], 0.3, 1)
+        self.assertAlmostEqual(errors['N3:f2.f4.EISF'][0], 0.03, 2)
 
     def test_two(self):
         """

--- a/test/workflows/model_selection/qldata_test.py
+++ b/test/workflows/model_selection/qldata_test.py
@@ -101,7 +101,7 @@ class QlDataTest(unittest.TestCase):
         self.assertAlmostEqual(errors['N2:f2.f3.EISF'][0], 0.011, 3)
 
         self.assertAlmostEqual(errors['N3:f2.f2.EISF'][0], 0.4, 1)
-        self.assertAlmostEqual(errors['N3:f2.f3.EISF'][0], 0.0116, 3)
+        self.assertAlmostEqual(errors['N3:f2.f3.EISF'][0], 0.116, 2)
         self.assertAlmostEqual(errors['N3:f2.f4.EISF'][0], 0.3, 1)
 
     def test_two(self):


### PR DESCRIPTION
The error for the EISF was using the wrong index since the number of parameters for the lorentzian is 2, instead of the normal 3, due to the tied peak centre. 